### PR TITLE
Upgrade to v0.83.0

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Outline"
 description.en = "Wiki and knowledge base for teams"
 description.fr = "Wiki et base de connaissances pour les équipes"
 
-version = "0.81.1~ynh2"
+version = "0.82.0~ynh1"
 
 maintainers = ["Raoul de Limezy"]
 
@@ -58,8 +58,8 @@ ram.runtime = "50M"
 
 [resources]
     [resources.sources.main]
-    url = "https://github.com/outline/outline/archive/refs/tags/v0.81.1.tar.gz"
-    sha256 = "d7b6f249db9a5cade0422b206e648ac53558f7af694b283353f031bb8b87a1b9"
+    url = "https://github.com/outline/outline/archive/refs/tags/v0.82.0.tar.gz"
+    sha256 = "6a1c594d7516eafc3e35f66d93220327ab0b059d672098a0fa523d6eed621d67"
 
     autoupdate.strategy = "latest_github_release"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Outline"
 description.en = "Wiki and knowledge base for teams"
 description.fr = "Wiki et base de connaissances pour les équipes"
 
-version = "0.82.0~ynh1"
+version = "0.83.0~ynh1"
 
 maintainers = ["Raoul de Limezy"]
 
@@ -58,8 +58,8 @@ ram.runtime = "50M"
 
 [resources]
     [resources.sources.main]
-    url = "https://github.com/outline/outline/archive/refs/tags/v0.82.0.tar.gz"
-    sha256 = "6a1c594d7516eafc3e35f66d93220327ab0b059d672098a0fa523d6eed621d67"
+    url = "https://github.com/outline/outline/archive/refs/tags/v0.83.0.tar.gz"
+    sha256 = "8ef5d2b259e813901cdcf4cd902cc397326e40a4c1fcfdf4dca19bb3ff916e0c"
 
     autoupdate.strategy = "latest_github_release"
 


### PR DESCRIPTION
Upgrade sources
- `main` v0.83.0: https://github.com/outline/outline/releases/tag/v0.83.0

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
