### PR TITLE
Fix missing antifeature non-totally-free-upstream

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -19,6 +19,10 @@ admindoc = "https://www.getoutline.com/developers"
 userdoc = "https://www.getoutline.com/about"
 code = "https://github.com/outline/outline"
 
+[antifeatures]
+not-totally-free-upstream.en = "Must not be used as a commercial service to third parties"
+not-totally-free-upstream.fr = "Ne doit pas être utilisé comme un service commercial pour des tiers"
+
 [integration]
 yunohost = ">= 11.2.30"
 architectures = "all"


### PR DESCRIPTION
## Problem

- The BUSL license is not totally free.

## Solution

- it should be marked as an antifeature in the manifest

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
