### PR TITLE
Change OIDC server name

### DIFF
--- a/conf/.env
+++ b/conf/.env
@@ -50,7 +50,7 @@ OIDC_USERINFO_URI=__DEX_USER_URI__
 OIDC_USERNAME_CLAIM=preferred_username
 
 # Display name for OIDC authentication
-OIDC_DISPLAY_NAME=membre (mot de passe)
+OIDC_DISPLAY_NAME="YunoHost"
 
 # Space separated auth scopes.
 OIDC_SCOPES="openid profile email"


### PR DESCRIPTION
## Problem

The current "membre (mot de passe)" text for OIDC login is a bit weird.

In the Outline admin:
<img width="364" height="253" alt="image" src="https://github.com/user-attachments/assets/7de8ce69-fca1-49b3-a577-978333628ea7" />
<br />
and on the login page:
<img width="364" height="325" alt="image" src="https://github.com/user-attachments/assets/ba000b8a-5c3f-4f51-8f2a-d3fd75d309a8" />

Ideally, we could use a global setting from the YunoHost core to be used across all apps with similar login. This feature does not exist.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
